### PR TITLE
Bugfix: Resolve typo in `build` condition

### DIFF
--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -52,7 +52,7 @@ jobs:
     # Don't run on closed PRs (required since the cleanup step will run on
     # this event trigger)
     # yamllint disable-line rule:line-length
-    if: ${{ ! ( github.event.name == 'pull_request' && github.event.action == 'closed') }}
+    if: ${{ ! ( github.event_name == 'pull_request' && github.event.action == 'closed') }}
     runs-on: ubuntu-latest
     outputs:
       image-name: ${{ steps.save-image-name.outputs.image-name }}

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -51,13 +51,8 @@ jobs:
   build:
     # Don't run on closed PRs (required since the cleanup step will run on
     # this event trigger)
-    if: |
-      ${{
-        ! (
-          github.event.name == 'pull_request' &&
-          github.event.action == 'closed'
-        )
-      }}
+    # yamllint disable-line rule:line-length
+    if: ${{ ! ( github.event.name == 'pull_request' && github.event.action == 'closed') }}
     runs-on: ubuntu-latest
     outputs:
       image-name: ${{ steps.save-image-name.outputs.image-name }}


### PR DESCRIPTION
Merging https://github.com/ccao-data/model-res-avm/pull/59 revealed a bug in the `build-and-run-batch-job` workflow: As evidenced by [this workflow run](https://github.com/ccao-data/model-res-avm/actions/runs/6870456156), the `build` step is not getting skipped properly on the `pull_request.closed` event.

The root problem here is that we have the wrong reference for the workflow event name (`github.event.name` instead of `github.event_name`). (It would be nice if GitHub raised an error for typos like this, but we work with what we have.) This PR fixes this typo such that only the `cleanup` step runs when a PR is closed.

Workflow with evidence that this fix works: https://github.com/ccao-data/model-condo-avm/actions/runs/6879724275