### PR TITLE
Allow callers to set Batch job container env vars in `build-and-run-batch-job` workflow

### DIFF
--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -63,7 +63,6 @@ on:
         required: true
       CONTAINER_ENV_VARS:
         required: false
-        default: ""
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -198,12 +198,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Print output and exit early to test container-env-vars
-        run: |
-          echo "${{ steps.parse-env-vars.outputs.environment}}"
-          exit 1
-        shell: bash
-
       - name: Setup Terraform
         uses: ./actions/setup-terraform
         with:

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -57,10 +57,21 @@ on:
         default: fargate
 
     secrets:
+      # The ARN for the IAM role that the workflow will assume in order to make
+      # requests to AWS
       AWS_IAM_ROLE_TO_ASSUME_ARN:
         required: true
+      # The ID of the AWS account where requests will be sent; this is not
+      # actually used in any requests, but is instead masked to ensure that the
+      # workflow never accidentally logs it
       AWS_ACCOUNT_ID:
         required: true
+      # A newline-delimited list of key-value pairs representing environment
+      # variables that will be set in the Batch job container. Example:
+      #
+      # CONTAINER_ENV_VARS: |
+      #   FOO=foo
+      #   BAR=${{ secrets.bar }}
       CONTAINER_ENV_VARS:
         required: false
 
@@ -190,12 +201,6 @@ jobs:
             done <<< "$ENV_VARS"
             echo "environment=[$(IFS=, ; echo "${OUTPUT_ARRAY[*]}")]" >> "$GITHUB_OUTPUT"
           fi
-        shell: bash
-
-      - name: Print output and exit early to test container-env-vars
-        run: |
-          echo "${{ steps.parse-env-vars.outputs.environment}}"
-          exit 1
         shell: bash
 
       - name: Setup Terraform

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -193,6 +193,12 @@ jobs:
           fi
         shell: bash
 
+      - name: Print output and exit early to test container-env-vars
+        run: |
+          echo "${{ steps.parse-env-vars.outputs.environment}}"
+          exit 1
+        shell: bash
+
       - name: Setup Terraform
         uses: ./actions/setup-terraform
         with:

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -174,6 +174,7 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ./actions/
 
+      # yamllint disable rule:line-length
       - name: Parse and mask container env vars
         id: parse-env-vars
         run: |
@@ -202,6 +203,7 @@ jobs:
             echo "environment=[$(IFS=, ; echo "${OUTPUT_ARRAY[*]}")]" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
+      # yamllint enable rule:line-length
 
       - name: Setup Terraform
         uses: ./actions/setup-terraform

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -55,20 +55,15 @@ on:
         # validation in a step of the `build` job
         type: string
         default: fargate
-      container-env-vars:
-        description: >
-          A newline-separated string of environment variables to set in the
-          container that runs the Batch job. These variables will be masked in
-          GitHub Actions output to ensure they are never printed.
-        required: false
-        type: string
-        default: ""
 
     secrets:
       AWS_IAM_ROLE_TO_ASSUME_ARN:
         required: true
       AWS_ACCOUNT_ID:
         required: true
+      CONTAINER_ENV_VARS:
+        required: false
+        default: ""
 
 env:
   DOCKER_REGISTRY: ghcr.io
@@ -173,9 +168,9 @@ jobs:
         id: parse-env-vars
         run: |
           # Use $'' to encapsulate string in order to preserve newlines
-          ENV_VARS=$'${{ inputs.container-env-vars }}'
+          ENV_VARS=$'${{ secrets.CONTAINER_ENV_VARS }}'
           if [ -z "$ENV_VARS" ]; then
-            echo "container-env-vars is not defined; skipping"
+            echo "CONTAINER_ENV_VARS is not defined; skipping"
             echo "environment=[]" >> "$GITHUB_OUTPUT"
           else
             declare -a OUTPUT_ARRAY
@@ -183,7 +178,7 @@ jobs:
               # Our method of iterating the newline-delimited string can
               # introduce empty lines, so we need to be sure to filter them out
               if [ -z "$line" ]; then
-                echo "Encountered empty line in container-env-vars; skipping"
+                echo "Encountered empty line in CONTAINER_ENV_VARS; skipping"
               else
                 VAR_ARRAY=(${line//=/ })
                 VAR_KEY=${VAR_ARRAY[0]}

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -55,6 +55,14 @@ on:
         # validation in a step of the `build` job
         type: string
         default: fargate
+      container-env-vars:
+        description: >
+          A newline-separated string of environment variables to set in the
+          container that runs the Batch job. These variables will be masked in
+          GitHub Actions output to ensure they are never printed.
+        required: false
+        type: string
+        default: ""
 
     secrets:
       AWS_IAM_ROLE_TO_ASSUME_ARN:
@@ -161,6 +169,35 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ./actions/
 
+      - name: Parse and mask container env vars
+        id: parse-env-vars
+        run: |
+          # Use $'' to encapsulate string in order to preserve newlines
+          ENV_VARS=$'${{ inputs.container-env-vars }}'
+          if [ -z "$ENV_VARS" ]; then
+            echo "container-env-vars is not defined; skipping"
+            echo "environment=[]" >> "$GITHUB_OUTPUT"
+          else
+            declare -a OUTPUT_ARRAY
+            while IFS= read -r line; do
+              VAR_ARRAY=(${line//=/ })
+              VAR_KEY=${VAR_ARRAY[0]}
+              VAR_VAL=${VAR_ARRAY[1]}
+              # Env vars are often sensitive, so mask the value
+              echo "::add-mask::$VAR_VAL"
+              # Transform the var into the key/val JSON format that AWS expects
+              OUTPUT_ARRAY+=("{\"name\":\"${VAR_KEY}\",\"value\":\"${VAR_VAL}\"}")
+            done <<< "$ENV_VARS"
+            echo "environment=[$(IFS=, ; echo "${OUTPUT_ARRAY[*]}")]" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      - name: Print output and exit early to test container-env-vars
+        run: |
+          echo "${{ steps.parse-env-vars.outputs.environment}}"
+          exit 1
+        shell: bash
+
       - name: Setup Terraform
         uses: ./actions/setup-terraform
         with:
@@ -196,16 +233,25 @@ jobs:
             terraform-bin output -raw batch_job_definition_arn \
           )"
 
+          if [ -z "$BATCH_JOB_ENVIRONMENT" ]; then
+            BATCH_JOB_CONTAINER_OVERRIDES="{}"
+          else
+            BATCH_JOB_CONTAINER_OVERRIDES="{\"environment\":${BATCH_JOB_ENVIRONMENT}}"
+          fi
+
           BATCH_JOB_DETAILS=$(\
             aws batch submit-job \
               --job-name "$BATCH_JOB_NAME" \
               --job-definition "$BATCH_JOB_DEFINITION" \
               --job-queue "$BATCH_JOB_QUEUE" \
+              --container-overrides "$BATCH_JOB_CONTAINER_OVERRIDES"
           )
           BATCH_JOB_ID=$(echo $BATCH_JOB_DETAILS | jq -r ".jobId")
           echo "batch-job-id=$BATCH_JOB_ID" >> "$GITHUB_OUTPUT"
         shell: bash
         working-directory: ${{ env.TF_WORKDIR }}
+        env:
+          BATCH_JOB_ENVIRONMENT: ${{ steps.parse-env-vars.outputs.environment }}
 
       - name: Wait for Batch job to start and print link to AWS logs
         run: |

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -180,13 +180,19 @@ jobs:
           else
             declare -a OUTPUT_ARRAY
             while IFS= read -r line; do
-              VAR_ARRAY=(${line//=/ })
-              VAR_KEY=${VAR_ARRAY[0]}
-              VAR_VAL=${VAR_ARRAY[1]}
-              # Env vars are often sensitive, so mask the value
-              echo "::add-mask::$VAR_VAL"
-              # Transform the var into the key/val JSON format that AWS expects
-              OUTPUT_ARRAY+=("{\"name\":\"${VAR_KEY}\",\"value\":\"${VAR_VAL}\"}")
+              # Our method of iterating the newline-delimited string can
+              # introduce empty lines, so we need to be sure to filter them out
+              if [ -z "$line" ]; then
+                echo "Encountered empty line in container-env-vars; skipping"
+              else
+                VAR_ARRAY=(${line//=/ })
+                VAR_KEY=${VAR_ARRAY[0]}
+                VAR_VAL=${VAR_ARRAY[1]}
+                # Env vars are often sensitive, so mask the value
+                echo "::add-mask::$VAR_VAL"
+                # Transform the var into the key/val JSON format that AWS expects
+                OUTPUT_ARRAY+=("{\"name\":\"${VAR_KEY}\",\"value\":\"${VAR_VAL}\"}")
+              fi
             done <<< "$ENV_VARS"
             echo "environment=[$(IFS=, ; echo "${OUTPUT_ARRAY[*]}")]" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
This PR allows workflows that call `build-and-run-batch-job` to set a `CONTAINER_ENV_VARS` secret that will be used to set environment variables in the container that runs the Batch job. We configure this option as a secret rather than an input because environmental variables are often secret values.

For an example of this change in action, see this res model PR: https://github.com/ccao-data/model-res-avm/pull/64/files