### PR TITLE
Make sure that resources in `build-and-run-batch-job` follow Batch naming rules

### DIFF
--- a/.github/workflows/build-and-run-batch-job-terraform/outputs.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/outputs.tf
@@ -27,7 +27,7 @@ output "batch_job_queue_arn" {
 
 output "batch_job_name" {
   description = "Name of the Batch job"
-  value       = var.batch_job_name
+  value       = local.batch_job_name
 }
 
 output "batch_container_image_name" {

--- a/setup-terraform/action.yaml
+++ b/setup-terraform/action.yaml
@@ -96,13 +96,13 @@ runs:
         # present, we must be in a PR context
         if [ -n "$GITHUB_HEAD_REF" ]; then
           echo "On pull request branch, setting terraform workspace to CI"
-          # Replace slashes and underscores with hyphens in the workspace name
+          # Replace special characters with hyphens in the workspace name
           # and force it to lowercase, since we use it to name resources and
           # we want to follow a consistent naming scheme
           WORKSPACE="$(echo $GITHUB_HEAD_REF | \
-                      sed -e 's/\//-/g' -e 's/_/-/g' | \
+                      sed -e 's/\//-/g' -e 's/_/-/g' -e 's/\./-/g' | \
                       tr '[:upper:]' '[:lower:]')"
-          BATCH_JOB_NAME="ci_${WORKSPACE}_${GITHUB_REPOSITORY//\//-}"
+          BATCH_JOB_NAME="z_ci_${WORKSPACE}_${GITHUB_REPOSITORY//\//-}"
 
         elif [[ "$GITHUB_REF_NAME" == "master" || \
                 "$GITHUB_REF_NAME" == "main" ]]; then


### PR DESCRIPTION
This PR updates the Terraform logic for the `build-and-run-batch-job` workflow to ensure that Batch resource names meet Batch naming requirements. In particular, [this workflow run](https://github.com/ccao-data/model-res-avm/actions/runs/7185793363/job/19569954212#step:7:46) revealed that we need to convert periods into valid characters, and we also should truncate the name after 128 characters to be safe.

See here for a test PR using these changes: https://github.com/ccao-data/model-res-avm The branch name contains periods and is long enough that it gets truncated before being applied as a Terraform resource name. Note that the workflow run technically failed, but that's only because I cancelled it after confirming that the Terraform config got applied as expected.

This PR also closes https://github.com/ccao-data/actions/issues/8.