### PR TITLE
Small improvements to `build-and-run-batch-job` UX

### DIFF
--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -197,7 +197,6 @@ resource "aws_batch_compute_environment" "ec2" {
     allocation_strategy = "BEST_FIT_PROGRESSIVE"
     bid_percentage      = 0
     min_vcpus           = 0
-    desired_vcpus       = 0
     max_vcpus           = 128
     instance_role       = data.aws_iam_instance_profile.ec2_service_role_for_ecs.arn
     instance_type       = local.gpu_enabled ? ["g5"] : ["optimal"]

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -277,7 +277,7 @@ jobs:
           BATCH_JOB_ID: ${{ steps.submit-job.outputs.batch-job-id }}
 
       - name: Wait for Batch job to complete
-        if: ${{ inputs.poll_for_status == 'true' }}
+        if: ${{ inputs.poll_for_status == true }}
         run: |
           ./actions/.github/workflows/scripts/batch_job_poll_status.sh \
             "$BATCH_JOB_ID"

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -290,6 +290,10 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ./actions/
 
+      - name: Exit early for testing
+        run: exit 1
+        shell: bash
+
       - name: Cleanup Terraform
         uses: ./actions/cleanup-terraform
         with:

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -55,6 +55,16 @@ on:
         # validation in a step of the `build` job
         type: string
         default: fargate
+      poll_for_status:
+        description: >
+          Whether to poll the Batch job status once it starts up. It can be
+          useful to disable polling if the job implements its own
+          status reporting in a third-party system, or if the job runtime
+          exceeds the GitHub workflow timeout of 6 hours.
+        required: false
+        type: boolean
+        default: true
+
 
     secrets:
       # The ARN for the IAM role that the workflow will assume in order to make
@@ -267,6 +277,7 @@ jobs:
           BATCH_JOB_ID: ${{ steps.submit-job.outputs.batch-job-id }}
 
       - name: Wait for Batch job to complete
+        if: ${{ inputs.poll_for_status == 'true' }}
         run: |
           ./actions/.github/workflows/scripts/batch_job_poll_status.sh \
             "$BATCH_JOB_ID"

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -290,10 +290,6 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ./actions/
 
-      - name: Exit early for testing
-        run: exit 1
-        shell: bash
-
       - name: Cleanup Terraform
         uses: ./actions/cleanup-terraform
         with:

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -275,8 +275,9 @@ jobs:
           BATCH_JOB_ID: ${{ steps.submit-job.outputs.batch-job-id }}
 
   cleanup:
-    # Only run on closed PRs, to destroy staging resources
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    # Only run on closed PRs or branches, to destroy staging resources
+    # yamllint disable-line rule:line-length
+    if: (github.event_name == 'pull_request' && github.event.action == 'closed') || (github.event_name == 'delete' && github.event.ref_type == 'branch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo code


### PR DESCRIPTION
This PR makes three improvements to the `build-and-run-batch-job` workflow:

1. Tweaks the `cleanup` step to run on [branch `delete` events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#delete), in case workflows have been run without a PR being opened
2. Removes the `desired_vcpus` param from the compute environment Terraform config, which is not necessary to provision environments and only serves to block runs from executing concurrently on the same branch
3. Adds a `poll_job_for_status` input variable that controls whether or not the workflow will poll the Batch job for its status once it starts running (useful for jobs that exceed the 6 hour GitHub workflow timeout)

Unfortunately, due to the fact that [`delete` events are only emitted if the workflow is configured to do so on the main branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#delete), we can't test improvement 1 until this PR and[ its associated `model-res-avm` PR](https://github.com/ccao-data/model-res-avm/pull/156) land. However, these two workflows which ran concurrently on the same branch until I cancelled them are evidence that improvement 2 works:

* https://github.com/ccao-data/model-res-avm/actions/runs/7478735171/job/20354362951
* https://github.com/ccao-data/model-res-avm/actions/runs/7478684114/job/20354270916

And these two workflows demonstrate that improvement 3 works:

* [Workflow with `poll_for_status` disabled](https://github.com/ccao-data/model-res-avm/actions/runs/7479000391/job/20355245455) (did not poll for status)
* [Workflow with `poll_for_status` enabled](https://github.com/ccao-data/model-res-avm/actions/runs/7479229549/job/20355985578) (did poll for status)

If improvement 1 doesn't end up working when merged to the main branch, I'll put up a fast follow to fix it.

Connects https://github.com/ccao-data/actions/issues/16.