### PR TITLE
Remove branch delete event handling from `build-and-run-batch-job`

### DIFF
--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -286,9 +286,9 @@ jobs:
           BATCH_JOB_ID: ${{ steps.submit-job.outputs.batch-job-id }}
 
   cleanup:
-    # Only run on closed PRs or branches, to destroy staging resources
+    # Only run on closed PRs, to destroy staging resources
     # yamllint disable-line rule:line-length
-    if: (github.event_name == 'pull_request' && github.event.action == 'closed') || (github.event_name == 'delete' && github.event.ref_type == 'branch')
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo code


### PR DESCRIPTION
This PR removes the handling for GitHub branch deletion events in `build-and-run-batch-job / cleanup` that was introduced in https://github.com/ccao-data/actions/pull/17.

Our reason for reverting this change is that the branch deletion handling logic is proving to be tricky to get right, and it can only be debugged when the code is on the repo main branch due to limitations in the [`delete` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#delete). We're plan to remove the logic for now and revisit it once we complete the design for https://github.com/ccao-data/actions/issues/16; in the meantime, we've decided to put up PRs for all branches that we use to run Batch jobs in https://github.com/ccao-data/model-res-avm, such that closing the PRs runs `build-and-run-batch-job / cleanup`.