### PR TITLE
Restrict non-GPU jobs to `m4` instances in `build-and-run-batch-job`

### DIFF
--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -199,7 +199,7 @@ resource "aws_batch_compute_environment" "ec2" {
     min_vcpus           = 0
     max_vcpus           = 128
     instance_role       = data.aws_iam_instance_profile.ec2_service_role_for_ecs.arn
-    instance_type       = local.gpu_enabled ? ["g5"] : ["optimal"]
+    instance_type       = local.gpu_enabled ? ["g5"] : ["c5"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
   }

--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -199,7 +199,7 @@ resource "aws_batch_compute_environment" "ec2" {
     min_vcpus           = 0
     max_vcpus           = 128
     instance_role       = data.aws_iam_instance_profile.ec2_service_role_for_ecs.arn
-    instance_type       = local.gpu_enabled ? ["g5"] : ["c5"]
+    instance_type       = local.gpu_enabled ? ["g5"] : ["c5", "m4"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
   }

--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -199,7 +199,7 @@ resource "aws_batch_compute_environment" "ec2" {
     min_vcpus           = 0
     max_vcpus           = 128
     instance_role       = data.aws_iam_instance_profile.ec2_service_role_for_ecs.arn
-    instance_type       = local.gpu_enabled ? ["g5"] : ["m4.10xlarge"]
+    instance_type       = local.gpu_enabled ? ["g5"] : ["m4"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
   }

--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -199,7 +199,7 @@ resource "aws_batch_compute_environment" "ec2" {
     min_vcpus           = 0
     max_vcpus           = 128
     instance_role       = data.aws_iam_instance_profile.ec2_service_role_for_ecs.arn
-    instance_type       = local.gpu_enabled ? ["g5"] : ["m4"]
+    instance_type       = local.gpu_enabled ? ["g5"] : ["m4.10xlarge"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
   }

--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -199,7 +199,7 @@ resource "aws_batch_compute_environment" "ec2" {
     min_vcpus           = 0
     max_vcpus           = 128
     instance_role       = data.aws_iam_instance_profile.ec2_service_role_for_ecs.arn
-    instance_type       = local.gpu_enabled ? ["g5"] : ["c5", "m4"]
+    instance_type       = local.gpu_enabled ? ["g5"] : ["m4"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
   }


### PR DESCRIPTION
This PR updates the compute environment config for the `build-and-run-batch-job` workflow to restrict non-GPU jobs to the `m4` instance family. I've noticed that when `m4.10xlarge` is unavailable, Batch often provisions an `r4.16xlarge` instance, which is memory-optimized and so are comparatively more expensive for less compute. (You can compare pricing and specs for instances on [the AWS EC2 pricing page](https://aws.amazon.com/ec2/pricing/on-demand/)). This PR should prevent Batch from making that mistake in the future.

It may eventually make sense to test out other instance types than `m4`; in the course of developing this PR, I tried `c5` compute-optimized instances, but the memory for the equivalently-priced instance (`c5.12xlarge`) wasn't quite good enough. For now, we know that `m4` instances have been working, so this change should codify that choice and ensure we don't accidentally pay more for worse `r4` instances.

Note one risk of this change: If _no_ instances in the `m4` family are available, Batch will no longer have the option of falling back to other instance types (particularly `r4`). This could result in some of our Batch jobs getting stuck in the `RUNNABLE` state for long periods of time, which will result in the `build-and-run-batch-job` workflow raising a timeout error during the startup step. I experienced this while testing a config that _only_ allowed `m4.10xlarge` instances, but that immediately resulted in a job getting stuck in the `RUNNABLE` state, so I figure it's not worth it.

I tested this change by pinning https://github.com/ccao-data/model-res-avm/pull/106 to this branch, running a couple of workflows, and confirming that starting a new job only provisioned `m4` instances. (Once it provisioned an `m4.10xlarge` instance, which is the instance that we target with our compute/memory allocation, and once it provisioned the next-biggest instance, `m4.16xlarge`.) If we decide to move in this direction, I'll put up a fast follow PR against `model-res-avm` that changes the CPU and memory allocation to match `c5.9xlarge` or `c5.12xlarge` after merging this PR.