### PR TITLE
Change pre-commit ref branch to main

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@create-composite-pre-commit-action
+        uses: ccao-data/actions/pre-commit@main


### PR DESCRIPTION
This PR changes the reference from the old branch name that has been merged to the main branch. Context here https://github.com/ccao-data/actions/pull/22#discussion_r1571432187.