### PR TITLE
Fix R pre-commit caching issues

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@main
+        uses: ccao-data/actions/pre-commit@dfsnow/fix-styler-cache

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -1,6 +1,7 @@
 name: pre-commit
 description: Runs pre-commit hooks
 
+# yamllint disable rule:line-length
 runs:
   using: composite
   steps:

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -33,9 +33,6 @@ runs:
           ${{ env.R_CACHE_ROOTPATH }}/R
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml', '$DESCRIPTION_FILE', '$LOCK_FILE' ) }}
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files
       shell: bash

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -30,6 +30,9 @@ runs:
           ${{ env.XDG_CACHE_HOME }}/pip
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files
       shell: bash

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -30,6 +30,7 @@ runs:
           ${{ env.XDG_CACHE_HOME }}/pre-commit
           ${{ env.R_CACHE_ROOTPATH }}/styler-perm
           ${{ env.R_CACHE_ROOTPATH }}/R
+          ${{ env.R_CACHE_ROOTPATH }}/pip
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Run pre-commit

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -11,13 +11,22 @@ runs:
       run: sudo apt-get install pre-commit
       shell: bash
 
+    - name: Set cache paths
+      run: |
+        echo "XDG_CACHE_HOME=$RUNNER_TEMP" >> $GITHUB_ENV
+        echo "R_CACHE_ROOTPATH=$RUNNER_TEMP" >> $GITHUB_ENV
+      shell: bash
+
     - name: Cache pre-commit environment
       uses: actions/cache@v4
       with:
         path: |
-          ~/.cache/pre-commit
-          ~/.cache/R
+          ${{ env.XDG_CACHE_HOME }}/pre-commit
+          ${{ env.R_CACHE_ROOTPATH }}/R
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
 
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -15,6 +15,7 @@ runs:
       run: |
         echo "XDG_CACHE_HOME=$RUNNER_TEMP" >> $GITHUB_ENV
         echo "R_CACHE_ROOTPATH=$RUNNER_TEMP" >> $GITHUB_ENV
+        echo "TMPDIR=$RUNNER_TEMP" >> $GITHUB_ENV
       shell: bash
 
     - name: Find R cache key files

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -33,6 +33,9 @@ runs:
           ${{ env.R_CACHE_ROOTPATH }}/pip
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files
       shell: bash

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -12,17 +12,15 @@ runs:
       run: sudo apt-get install pre-commit
       shell: bash
 
-    - name: Set cache paths
+    - name: Set styler cache path
       run: |
-        echo "XDG_CACHE_HOME=$RUNNER_TEMP" >> $GITHUB_ENV
-        echo "R_CACHE_ROOTPATH=$RUNNER_TEMP" >> $GITHUB_ENV
-        echo "TMPDIR=$RUNNER_TEMP" >> $GITHUB_ENV
+        echo "options(styler.cache_root = 'styler-perm', R.cache.rootPath = \'$RUNNER_TEMP\')" > $HOME/.Rprofile
       shell: bash
 
-    - name: Find R cache key files
+    - name: Set other cache paths
       run: |
-        echo "DESCRIPTION_FILE=$(find $RUNNER_TEMP/pre-commit -maxdepth 2 -type f -name 'DESCRIPTION')" >> $GITHUB_ENV
-        echo "LOCK_FILE=$(find $RUNNER_TEMP/pre-commit -maxdepth 2 -type f -name 'renv.lock')" >> $GITHUB_ENV
+        echo "XDG_CACHE_HOME=$RUNNER_TEMP" >> $GITHUB_ENV
+        echo "TMPDIR=$RUNNER_TEMP" >> $GITHUB_ENV
       shell: bash
 
     - name: Cache pre-commit environment
@@ -32,7 +30,7 @@ runs:
           ${{ env.XDG_CACHE_HOME }}/pre-commit
           ${{ env.R_CACHE_ROOTPATH }}/styler-perm
           ${{ env.R_CACHE_ROOTPATH }}/R
-        key: pre-commit-${{ hashFiles('.pre-commit-config.yaml', '$DESCRIPTION_FILE', '$LOCK_FILE' ) }}
+        key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -22,7 +22,7 @@ runs:
       with:
         path: |
           ${{ env.XDG_CACHE_HOME }}/pre-commit
-          ${{ env.R_CACHE_ROOTPATH }}/R
+          ${{ env.R_CACHE_ROOTPATH }}/styler-perm
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Setup tmate session

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -14,7 +14,7 @@ runs:
 
     - name: Set styler cache path
       run: |
-        echo "options(styler.cache_root = 'styler-perm', R.cache.rootPath = \'$RUNNER_TEMP\')" > $HOME/.Rprofile
+        echo "options(styler.cache_root = 'styler-perm', R.cache.rootPath = '$RUNNER_TEMP')" > $HOME/.Rprofile
       shell: bash
 
     - name: Set other cache paths
@@ -28,9 +28,9 @@ runs:
       with:
         path: |
           ${{ env.XDG_CACHE_HOME }}/pre-commit
-          ${{ env.R_CACHE_ROOTPATH }}/styler-perm
-          ${{ env.R_CACHE_ROOTPATH }}/R
-          ${{ env.R_CACHE_ROOTPATH }}/pip
+          ${{ env.XDG_CACHE_HOME }}/styler-perm
+          ${{ env.XDG_CACHE_HOME }}/R
+          ${{ env.XDG_CACHE_HOME }}/pip
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Setup tmate session

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -1,7 +1,6 @@
 name: pre-commit
 description: Runs pre-commit hooks
 
-# yamllint disable rule:line-length
 runs:
   using: composite
   steps:
@@ -12,9 +11,8 @@ runs:
       run: sudo apt-get install pre-commit
       shell: bash
 
-    - name: Set styler cache path
-      run: |
-        echo "options(styler.cache_root = 'styler-perm', R.cache.rootPath = '$RUNNER_TEMP')" > $HOME/.Rprofile
+    - name: Disable R.cache integration
+      run: echo "options(R.cache.enabled = FALSE)" > $HOME/.Rprofile
       shell: bash
 
     - name: Set other cache paths
@@ -28,13 +26,9 @@ runs:
       with:
         path: |
           ${{ env.XDG_CACHE_HOME }}/pre-commit
-          ${{ env.XDG_CACHE_HOME }}/styler-perm
           ${{ env.XDG_CACHE_HOME }}/R
           ${{ env.XDG_CACHE_HOME }}/pip
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
 
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -17,13 +17,20 @@ runs:
         echo "R_CACHE_ROOTPATH=$RUNNER_TEMP" >> $GITHUB_ENV
       shell: bash
 
+    - name: Find R cache key files
+      run: |
+        echo "DESCRIPTION_FILE=$(find $RUNNER_TEMP/pre-commit -maxdepth 2 -type f -name 'DESCRIPTION')" >> $GITHUB_ENV
+        echo "LOCK_FILE=$(find $RUNNER_TEMP/pre-commit -maxdepth 2 -type f -name 'renv.lock')" >> $GITHUB_ENV
+      shell: bash
+
     - name: Cache pre-commit environment
       uses: actions/cache@v4
       with:
         path: |
           ${{ env.XDG_CACHE_HOME }}/pre-commit
           ${{ env.R_CACHE_ROOTPATH }}/styler-perm
-        key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          ${{ env.R_CACHE_ROOTPATH }}/R
+        key: pre-commit-${{ hashFiles('.pre-commit-config.yaml', '$DESCRIPTION_FILE', '$LOCK_FILE' ) }}
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
The styler R pre-commit action was intermittently failing for some repos. This was particularly true when making a commit after a long gap between commits. An example of the failure can be [found here](https://github.com/ccao-data/ptaxsim/actions/runs/8943254076/job/24567557655).

- Styler calls `R.cache::getCachePath()` [when it loads](https://github.com/r-lib/styler/blob/f5744da371242da992fff46b35253aa80cba6844/R/zzz.R#L79)

