### PR TITLE
Upgrade pre-commit and its hooks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@main
+        uses: ./pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
   - repo: https://github.com/syntaqx/git-hooks
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: 3.10.12

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -14,19 +14,8 @@ runs:
     - name: Cache pre-commit environment
       uses: actions/cache@v4
       with:
-        path: |
-          ~/.cache/pre-commit
-          ~/.cache/R
+        path: ~/.cache/pre-commit
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-    - name: Permissions check on R cache (debugging)
-      run: >
-        if [ -d /home/runner/.cache/R ]; then
-          ls -lah /home/runner/.cache/R/R.cache
-        else
-          echo "Directory /home/runner/.cache/R/R.cache not exist."
-        fi
-      shell: bash
 
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -14,7 +14,9 @@ runs:
     - name: Cache pre-commit environment
       uses: actions/cache@v4
       with:
-        path: ~/.cache/pre-commit
+        path: |
+          ~/.cache/pre-commit
+          ~/.cache/R
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Run pre-commit

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -8,7 +8,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Install pre-commit
-      run: sudo apt-get install pre-commit
+      run: pip install pre-commit
       shell: bash
 
     - name: Cache pre-commit environment


### PR DESCRIPTION
In the course of investigating https://github.com/lorenzwalthert/precommit/issues/571, I realized that our pre-commit hooks are outdated, and we're running an old version of pre-commit due to installing from apt instead of PyPi. This PR updates pre-commit and its hooks for the sake of keeping things tidy and ruling out any problems due to package versions.

I also tested these changes as part of https://github.com/ccao-data/model-res-avm/pull/243, to confirm that the R hooks still work.