### PR TITLE
Update Terraform configs for `build-and-run-batch-job` workflow

### DIFF
--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -220,19 +220,27 @@ resource "aws_batch_compute_environment" "ec2" {
 # where its associated compute environment has reached max capacity. Docs here:
 # https://docs.aws.amazon.com/batch/latest/userguide/job_queues.html
 resource "aws_batch_job_queue" "fargate" {
-  count                = var.batch_compute_environment_backend == "fargate" ? 1 : 0
-  name                 = local.batch_job_name
-  compute_environments = [aws_batch_compute_environment.fargate[0].arn]
-  priority             = 0
-  state                = "ENABLED"
+  count    = var.batch_compute_environment_backend == "fargate" ? 1 : 0
+  name     = local.batch_job_name
+  priority = 0
+  state    = "ENABLED"
+
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.fargate[0].arn
+  }
 }
 
 resource "aws_batch_job_queue" "ec2" {
-  count                = var.batch_compute_environment_backend == "ec2" ? 1 : 0
-  name                 = local.batch_job_name
-  compute_environments = [aws_batch_compute_environment.ec2[0].arn]
-  priority             = 0
-  state                = "ENABLED"
+  count    = var.batch_compute_environment_backend == "ec2" ? 1 : 0
+  name     = local.batch_job_name
+  priority = 0
+  state    = "ENABLED"
+
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.ec2[0].arn
+  }
 }
 
 # Create a Batch job definition to define jobs. Job definitions provide the

--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -182,6 +182,11 @@ resource "aws_batch_compute_environment" "fargate" {
     security_group_ids = [data.aws_security_group.outbound_https.id]
     subnets            = data.aws_subnets.default.ids
   }
+
+  update_policy {
+    job_execution_timeout_minutes = 30
+    terminate_jobs_on_update      = false
+  }
 }
 
 resource "aws_batch_compute_environment" "ec2" {
@@ -202,6 +207,11 @@ resource "aws_batch_compute_environment" "ec2" {
     instance_type       = local.gpu_enabled ? ["g5"] : ["m4"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
+  }
+
+  update_policy {
+    job_execution_timeout_minutes = 30
+    terminate_jobs_on_update      = false
   }
 }
 


### PR DESCRIPTION
During our model fire drill yesterday, Nicole ran a `build-and-run-model` workflow in `model-res-avm` that [failed](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:8:40). The root cause of the failure was somewhat complex, but ultimately transitory:

* Terraform needed to add a new default param `deregister_on_new_revision` to the AWS Batch job definition for the main branch, presumably because the default value for this param has changed in the past year since we provisioned the resource ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:7:55))
* The new param value for the job description caused a new revision to be created with version 6, since job definitions are immutable ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:7:65))
* For some reason, Terraform output the old version of the job definition (5) instead of the new one (6) after applying the changes ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:7:84))
* Because Terraform had instructed AWS to deregister the old version of the job definition after creating a new revision, Batch threw an error when we tried to start a job saying that the job definition version 5 was no longer active ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:8:40))

The fact that the workflow errored out instead of continuing with the old job definition version is actually a good thing, because we don't want the workflow to accidentally use an old job definition. I don't really know why Terraform output the wrong version, though; I tested out a similar job definition revision and confirmed that Terraform output the correct version ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10965785653/job/30452379880#step:7:98)). My best guess is that something specific to the change to the`deregister_on_new_revision` param caused Terraform to be confused about the version, but now that old resources have been converted to `true` for this param (and Terraform will initialize new resources with `true` by default), I don't think there's anything we can do other than wait and see if it happens again.

In the meantime, this PR fixes a few other problems that I noticed while debugging the above workflow:

* The `aws_batch_compute_environment.update_policy` attribute is now mandatory and will constantly try to update the resource to add defaults unless present ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:7:45))
* The `aws_batch_job_queue.compute_environments` attribute is deprecated and needs to be replaced with the newer attribute `aws_batch_job_queue.compute_environment_order` ([logs](https://github.com/ccao-data/model-res-avm/actions/runs/10944766566/job/30387841793#step:7:72))

See [this workflow run](https://github.com/ccao-data/model-res-avm/actions/runs/10965998448/job/30453032740#step:6:15) for confirmation that these changes produce a valid Terraform config with no deprecation warnings.