### PR TITLE
Update pre-commit action to cache R `additional_dependencies`

### DIFF
--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -25,6 +25,7 @@ runs:
         path: |
           ~/.cache/pre-commit
           ~/.cache/R
+          ~/.local/share/renv/cache
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Run pre-commit


### PR DESCRIPTION
While working on a [PR](https://github.com/ccao-data/model-res-avm/pull/315) that uses `additional_dependencies` for a local R pre-commit hook, I noticed that workflow runs with a cache hit were failing with [an error indicating that the dependencies were not installed](https://github.com/ccao-data/model-res-avm/actions/runs/12717896768/job/35455826864#step:3:1439), while non-cached runs were succeeding. After some debugging, I realized that pre-commit symlinks to the `~/.local/share/renv/cache` folder for local hooks. This PR adds that directory to the workflow cache so that we can properly pull dependencies in case of cache hit.

[See here](https://github.com/ccao-data/model-res-avm/actions/runs/12718139916/job/35456135606) for an example of a cached run that succeeded.