### PR TITLE
Add `command` argument to `build-and-run-batch-job` to override container command

### DIFF
--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -288,8 +288,11 @@ jobs:
           )"
 
           # Parse contianer override configuration for Batch job. Batch expects
-          # a JSON string
-          BATCH_JOB_OVERRIDE_ENVIRONMENT=$([ -z "$BATCH_JOB_ENVIRONMENT" ] && echo "" || echo "\"environment\":\"${BATCH_JOB_ENVIRONMENT}\"")
+          # a JSON string for this parameter. Since we expect the
+          # BATCH_JOB_ENVIRONMENT variable to be a JSON array itself, we don't
+          # wrap it in quotes, but we _do_ wrap BATCH_JOB_COMMAND since that
+          # variable should be a string
+          BATCH_JOB_OVERRIDE_ENVIRONMENT=$([ -z "$BATCH_JOB_ENVIRONMENT" ] && echo "" || echo "\"environment\":${BATCH_JOB_ENVIRONMENT}")
           BATCH_JOB_OVERRIDE_COMMAND=$([ -z "$BATCH_JOB_COMMAND" ] && echo "" || echo "\"command\":\"${BATCH_JOB_COMMAND}\"")
           BATCH_JOB_OVERRIDE_SEPARATOR=$([ -z "$BATCH_JOB_ENVIRONMENT" || -z "$BATCH_JOB_COMMAND" ] && echo "" || echo ",")
           BATCH_JOB_CONTAINER_OVERRIDES="{${BATCH_JOB_OVERRIDE_ENVIRONMENT}${BATCH_JOB_OVERRIDE_SEPARATOR}${BATCH_JOB_OVERRIDE_COMMAND}}"

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -293,7 +293,7 @@ jobs:
           # wrap it in quotes, but we _do_ wrap BATCH_JOB_COMMAND since that
           # variable should be a string
           BATCH_JOB_OVERRIDE_ENVIRONMENT=$([ -z "$BATCH_JOB_ENVIRONMENT" ] && echo "" || echo "\"environment\":${BATCH_JOB_ENVIRONMENT}")
-          BATCH_JOB_OVERRIDE_COMMAND=$([ -z "$BATCH_JOB_COMMAND" ] && echo "" || echo "\"command\":\"${BATCH_JOB_COMMAND}\"")
+          BATCH_JOB_OVERRIDE_COMMAND=$([ -z "$BATCH_JOB_COMMAND" ] && echo "" || echo "\"command\":[\"sh\", \"-c\", \"${BATCH_JOB_COMMAND}\"]")
           BATCH_JOB_OVERRIDE_SEPARATOR=$([ -z "$BATCH_JOB_ENVIRONMENT" || -z "$BATCH_JOB_COMMAND" ] && echo "" || echo ",")
           BATCH_JOB_CONTAINER_OVERRIDES="{${BATCH_JOB_OVERRIDE_ENVIRONMENT}${BATCH_JOB_OVERRIDE_SEPARATOR}${BATCH_JOB_OVERRIDE_COMMAND}}"
           echo "Container overrides: '${BATCH_JOB_CONTAINER_OVERRIDES}'"

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -75,6 +75,13 @@ on:
         required: false
         type: boolean
         default: true
+      command:
+        description: >
+          Optional override for the command that Batch will run on the
+          container.
+        required: false
+        type: string
+        default: ""
 
 
     secrets:
@@ -280,11 +287,13 @@ jobs:
             terraform-bin output -raw batch_job_definition_arn \
           )"
 
-          if [ -z "$BATCH_JOB_ENVIRONMENT" ]; then
-            BATCH_JOB_CONTAINER_OVERRIDES="{}"
-          else
-            BATCH_JOB_CONTAINER_OVERRIDES="{\"environment\":${BATCH_JOB_ENVIRONMENT}}"
-          fi
+          # Parse contianer override configuration for Batch job. Batch expects
+          # a JSON string
+          BATCH_JOB_OVERRIDE_ENVIRONMENT=$([ -z "$BATCH_JOB_ENVIRONMENT" ] && echo "" || echo "\"environment\":\"${BATCH_JOB_ENVIRONMENT}\"")
+          BATCH_JOB_OVERRIDE_COMMAND=$([ -z "$BATCH_JOB_COMMAND" ] && echo "" || echo "\"command\":\"${BATCH_JOB_COMMAND}\"")
+          BATCH_JOB_OVERRIDE_SEPARATOR=$([ -z "$BATCH_JOB_ENVIRONMENT" || -z "$BATCH_JOB_COMMAND" ] && echo "" || echo ", ")
+          BATCH_JOB_CONTAINER_OVERRIDES="{${BATCH_JOB_OVERRIDE_ENVIRONMENT}${BATCH_JOB_OVERRIDE_SEPARATOR}${BATCH_JOB_OVERRIDE_COMMAND}}"
+          echo "Container overrides: '${BATCH_JOB_CONTAINER_OVERRIDES}'"
 
           BATCH_JOB_DETAILS=$(\
             aws batch submit-job \
@@ -298,6 +307,7 @@ jobs:
         shell: bash
         working-directory: ${{ env.TF_WORKDIR }}
         env:
+          BATCH_JOB_COMMAND: ${{ inputs.command }}
           BATCH_JOB_ENVIRONMENT: ${{ steps.parse-env-vars.outputs.environment }}
 
       - name: Wait for Batch job to start and print link to AWS logs

--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -291,7 +291,7 @@ jobs:
           # a JSON string
           BATCH_JOB_OVERRIDE_ENVIRONMENT=$([ -z "$BATCH_JOB_ENVIRONMENT" ] && echo "" || echo "\"environment\":\"${BATCH_JOB_ENVIRONMENT}\"")
           BATCH_JOB_OVERRIDE_COMMAND=$([ -z "$BATCH_JOB_COMMAND" ] && echo "" || echo "\"command\":\"${BATCH_JOB_COMMAND}\"")
-          BATCH_JOB_OVERRIDE_SEPARATOR=$([ -z "$BATCH_JOB_ENVIRONMENT" || -z "$BATCH_JOB_COMMAND" ] && echo "" || echo ", ")
+          BATCH_JOB_OVERRIDE_SEPARATOR=$([ -z "$BATCH_JOB_ENVIRONMENT" || -z "$BATCH_JOB_COMMAND" ] && echo "" || echo ",")
           BATCH_JOB_CONTAINER_OVERRIDES="{${BATCH_JOB_OVERRIDE_ENVIRONMENT}${BATCH_JOB_OVERRIDE_SEPARATOR}${BATCH_JOB_OVERRIDE_COMMAND}}"
           echo "Container overrides: '${BATCH_JOB_CONTAINER_OVERRIDES}'"
 


### PR DESCRIPTION
This PR adds a new input variable to the `build-and-run-batch-job` workflow called `command` that callers can use to override the command that the Batch container runs. We do this by conditionally passing a `"command"` key to the `--container-overrides` option in the `submit-job` CLI ([docs](https://docs.aws.amazon.com/cli/latest/reference/batch/submit-job.html#options)).

I tested this out two different ways, see links for workflow logs:

* [`command: echo helloworld`](https://github.com/ccao-data/model-res-avm/actions/runs/14936324556/job/41964570309) (simple example)
* [`command: echo hello & echo world`](https://github.com/ccao-data/model-res-avm/actions/runs/14936540579/job/41965243232) (more complex, requires conditional evaluation, hence more similar to our real-world use cases as described in https://github.com/ccao-data/model-res-avm/issues/375 and https://github.com/ccao-data/pinval/issues/41)