### PR TITLE
Pin R version in `pre-commit` action to get around version resolution bug

### DIFF
--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "4.4"
+        r-version: "4.4.3"
         use-public-rspm: true
 
     - name: Install pre-commit


### PR DESCRIPTION
All of our repos that consume the pre-commit action in this repo started failing with a myserious renv installation error today:

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/local/bin/Rscript', '--vanilla', '/tmp/tmpoumm3lyz/script.R')
return code: 1
stdout:
    # Bootstrapping renv 1.1.4 ---------------------------------------------------
    - Downloading renv ... FAILED
stderr:
    Loading required namespace: renv
    Error in h(simpleError(msg, call)) : failed to download:
    All download methods failed
    Calls: source ... bootstrap -> withCallingHandlers -> renv_bootstrap_download
    Execution halted
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
```

It turns out that the root problem here is that the `setup-r` step passes R version `4.4`, which is currently resolving to R `3.0.0` in the underlying `rversions` node package (see https://github.com/r-hub/node-rversions/issues/34). Since renv 1.1.4 is not available for R version 3.0.0, the renv bootstrap step in `activate.R` fails while attempting to install https://github.com/lorenzwalthert/precommit.

While we wait for a more permanent fix, this PR works around the issue by pinning the R version directly to the `4.4.3` minor version in the `setup-r` step of this job.

See these workflow run logs for evidence that the change works: https://github.com/ccao-data/data-architecture/actions/runs/15124238450/job/42513183828?pr=822