### PR TITLE
Don't push container images to GHCR from forks in `build-and-run-batch-job`

### DIFF
--- a/.github/workflows/build-and-run-batch-job.yaml
+++ b/.github/workflows/build-and-run-batch-job.yaml
@@ -139,13 +139,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -160,7 +153,19 @@ jobs:
             type=ref,event=pr
             type=ref,event=tag
 
+      - name: Login to GitHub Container Registry
+        # Skip pushes to GHCR on PRs coming from forks
+        # yamllint disable-line rule:line-length
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
+        # yamllint disable-line rule:line-length
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         id: build-and-push
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
## Background

This PR tweaks the reusable `build-and-run-batch-job` workflow so that it will not push container images to GitHub Container Registry (GHCR) from PRs that originate from forks. This change is necessary in order to enable contributions from external contributors to projects that use this workflow, since external contributors generally do not have permission to push to our GHCR account.

The downside of this approach is that we won't be able to actually _run_ a batch job from a fork, since  the `build` job won't push the container image to the registry in order for the `run` job to use it. This is relevant because I could imagine wanting to test a batch job for a PR coming from a fork if that PR makes substantial code changes. However, I think this limitation is acceptable for now, since it's not even possible for us to run a model via `workflow_dispatch` if the branch is in a fork anyway -- those branches don't show up in the branch list when dispatching a workflow.

If we ever decide we want to be able to run batch jobs from forks in the future, a temporary workaround would be to copy the changes from the fork into a temporary branch in the main repo and run the code from that temporary branch. This wouldn't be a great long-term solution, but I think we should wait to see if this emerges as an important requirement for our projects before we pursue it any further. We've never really had contributions from external contributors that make substantial changes to the code before, so unless/until that happens, I don't think we need to worry too much about this.

## Testing

See this PR from a fork for evidence that fork PRs do not push to GHCR using the new version of this workflow: https://github.com/ccao-data/model-res-avm/pull/410

See this PR from a branch for evidence that non-fork PRs continue to push to GHCR: https://github.com/ccao-data/model-res-avm/pull/411