### PR TITLE
Downgrade `pre-commit` action to use R 4.4 to resolve R hooks installation error

### DIFF
--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Setup R
       uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
       with:
-        r-version: "4.5"
+        r-version: "4.4"
         use-public-rspm: true
 
     - name: Install pre-commit

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -7,12 +7,16 @@ runs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    - name: Install system requirements
+      run: sudo apt install libnode-dev
+      shell: bash
+
       # R is no longer preinstalled on GitHub runners as of Ubuntu 24.04, so we
       # need to install it to support consumers that are checking R code
     - name: Setup R
       uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
       with:
-        r-version: "4.4"
+        r-version: "4.5"
         use-public-rspm: true
 
     - name: Install pre-commit

--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -7,16 +7,12 @@ runs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Install system requirements
-      run: sudo apt install libnode-dev
-      shell: bash
-
       # R is no longer preinstalled on GitHub runners as of Ubuntu 24.04, so we
       # need to install it to support consumers that are checking R code
     - name: Setup R
       uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
       with:
-        r-version: "4.5"
+        r-version: "4.4"
         use-public-rspm: true
 
     - name: Install pre-commit


### PR DESCRIPTION
R pre-commit hooks (https://github.com/lorenzwalthert/precommit) are failing to install following the upgrade to R 4.5 in #41 due to a bug in a dependency package that is specific to R 4.5 (https://github.com/jeroen/V8/issues/204). While we wait for a resolution of that bug, this PR downgrades to R 4.4. As far as I know, there are no downsides to using R 4.4, other than the slight maintenance risk of using an R version in CI that we no longer use for local development.

I tested this change by pinning the `pre-commit` action to this branch in https://github.com/ccao-data/lightsnip/pull/26 and confirming it resolves the build errors.