### PR TITLE
Upgrade Batch EC2 compute environments to Amazon Linux 2023

### DIFF
--- a/.github/workflows/build-and-run-batch-job-terraform/main.tf
+++ b/.github/workflows/build-and-run-batch-job-terraform/main.tf
@@ -207,6 +207,10 @@ resource "aws_batch_compute_environment" "ec2" {
     instance_type       = local.gpu_enabled ? ["g5"] : ["m4"]
     security_group_ids  = [data.aws_security_group.outbound_https.id]
     subnets             = data.aws_subnets.default.ids
+
+    ec2_configuration {
+      image_type = local.gpu_enabled ? "ECS_AL2023_NVIDIA" : "ECS_AL2023"
+    }
   }
 
   update_policy {


### PR DESCRIPTION
Terraform defaults to Amazon Linux 2 for EC2 AMIs when creating Batch compute environments. [Amazon Linux 2 is now deprecated](https://docs.aws.amazon.com/batch/latest/userguide/ecs-al2-ami-deprecation.html), so we need to [upgrade our compute environments](https://docs.aws.amazon.com/batch/latest/userguide/ecs-migration-2023.html). 

I tested two model runs in `ccao-data/model-res-avm` and confirmed that they successfully provisioned compute environments with the upgraded image types:

- CPU compute environment: https://github.com/ccao-data/model-res-avm/actions/runs/27633742854/job/81715713096#step:7:75 
- GPU compute environment: https://github.com/ccao-data/model-res-avm/actions/runs/27634558895/job/81718417901#step:7:54

Closes #42.