### PR TITLE
Bump R version

### DIFF
--- a/pre-commit/action.yaml
+++ b/pre-commit/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Setup R
       uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
       with:
-        r-version: "4.4"
+        r-version: "4.5"
         use-public-rspm: true
 
     - name: Install pre-commit


### PR DESCRIPTION
It seems like the R hooks installation error [bug](https://github.com/ccao-data/actions/pull/43) on R 4.5 may have been resolved. We discovered that we were [having problems](https://github.com/ccao-data/lightsnip/actions/runs/28976456178/job/85984722040?pr=21) with a lightsnip PR using 4.4. We [tested the switch](https://github.com/ccao-data/lightsnip/actions/runs/29032460681/job/86168561866) to 4.5 the it fixes the pre-commit error.